### PR TITLE
charsetがうまく取得出来ないパターンがあったのを修正

### DIFF
--- a/src/components/pages/index/RithtPane/BodyTextHtml.tsx
+++ b/src/components/pages/index/RithtPane/BodyTextHtml.tsx
@@ -13,15 +13,18 @@ export const BodyTextHtml: React.FC<Props> = ({
   mailInfo,
 }): JSX.Element => {
   const contentType = (() => {
-    const regex = new RegExp('^Content-Type: text/html; .*$', 'gm')
+    const regex = new RegExp(
+      '^Content-Type: text/html;\\s*\\r?\\n?\\s*charset=.*$',
+      'gm'
+    )
     const matches = regex.exec(mailRaw)
     return matches && matches[0]
   })()
 
   const contentEncoding = (() => {
     const patterns = [
-      '^(?:Content-Type: text/html; .*)\\r?\\n(Content-Transfer-Encoding: .*)$',
-      '^(Content-Transfer-Encoding: .*)\\r?\\n(?:Content-Type: text/html; .*)$',
+      '^(?:Content-Type: text/html;\\s*\\r?\\n?\\s*charset=.*$)\\r?\\n(Content-Transfer-Encoding: .*)$',
+      '^(Content-Transfer-Encoding: .*)\\r?\\n(?:Content-Type: text/html;.*)$',
     ]
 
     const results = patterns

--- a/src/components/pages/index/RithtPane/BodyTextPlain.tsx
+++ b/src/components/pages/index/RithtPane/BodyTextPlain.tsx
@@ -13,15 +13,18 @@ export const BodyTextPlain: React.FC<Props> = ({
   mailInfo,
 }): JSX.Element => {
   const contentType = (() => {
-    const regex = new RegExp('^Content-Type: text/plain; .*$', 'gm')
+    const regex = new RegExp(
+      '^Content-Type: text/plain;\\s*\\r?\\n?\\s*charset=.*$',
+      'gm'
+    )
     const matches = regex.exec(mailRaw)
     return matches && matches[0]
   })()
 
   const contentEncoding = (() => {
     const patterns = [
-      '^(?:Content-Type: text/plain; .*)\\r?\\n(Content-Transfer-Encoding: .*)$',
-      '^(Content-Transfer-Encoding: .*)\\r?\\n(?:Content-Type: text/plain; .*)$',
+      '^(?:Content-Type: text/plain;\\s*\\r?\\n?\\s*charset=.*)\\r?\\n(Content-Transfer-Encoding: .*)$',
+      '^(Content-Transfer-Encoding: .*)\\r?\\n(?:Content-Type: text/plain;.*)$',
     ]
 
     const results = patterns


### PR DESCRIPTION
# 概要

マルチパートのメールで、charsetが改行されている場合に検出出来ていなかったのを修正

# 今回対応したパターン

```
----==_mimepart_6438adb483a21_6f0ee3af808846989
Content-Type: text/html;
 charset=UTF-8
Content-Transfer-Encoding: quoted-printable
```