### PR TITLE
fix eslint rule `@typescript-eslint/no-unused-vars`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -59,9 +59,12 @@ export default [
       '@typescript-eslint/no-use-before-define': 0,
 
       '@typescript-eslint/no-unused-vars': [
-        2,
+        'error',
         {
           argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
         },
       ],
 


### PR DESCRIPTION
https://typescript-eslint.io/rules/no-unused-vars/#benefits-over-typescript